### PR TITLE
Improve Variable Naming in SinglePhotoPage

### DIFF
--- a/src/components/pages/SinglePhotoPage.js
+++ b/src/components/pages/SinglePhotoPage.js
@@ -20,46 +20,46 @@ const fetchUser = async (userId) => {
 }
 
 const SinglePhotoPage = () => {
-  const { photoId } = useParams() // get ID from url
+  const { photoId } = useParams()
 
   const {
-    isLoading: aIsLoading,
-    data: aData,
-    isError: aIsError,
-    error: aError,
+    isLoading: isPhotoLoading,
+    data: photoResponse,
+    isError: isPhotoError,
+    error: photoError,
   } = useQuery({
     queryKey: ["my-photo", photoId],
     queryFn: () => fetchPhoto(photoId),
   })
-  const albumId = aData?.data.albumId
-  const photoData = aData?.data
+  const albumId = photoResponse?.data.albumId
+  const photoData = photoResponse?.data
 
   const {
-    isLoading: bIsLoading,
-    data: bData,
-    isError: bIsError,
-    error: bError,
+    isLoading: isAlbumLoading,
+    data: albumResponse,
+    isError: isAlbumError,
+    error: albumError,
   } = useQuery({
     queryKey: ["my-album", albumId],
     queryFn: () => fetchAlbum(albumId),
     enabled: !!albumId,
   })
-  const userId = bData?.data.userId
-  const albumData = bData?.data
+  const userId = albumResponse?.data.userId
+  const albumData = albumResponse?.data
 
   const {
-    isLoading: cIsLoading,
-    data: cData,
-    isError: cIsError,
-    error: cError,
+    isLoading: isUserLoading,
+    data: userResponse,
+    isError: isUserError,
+    error: userError,
   } = useQuery({
     queryKey: ["my-user", userId],
     queryFn: () => fetchUser(userId),
     enabled: !!userId,
   })
-  const userData = cData?.data
+  const userData = userResponse?.data
 
-  if (aIsLoading || bIsLoading || cIsLoading) {
+  if (isPhotoLoading || isAlbumLoading || isUserLoading) {
     return (
       <>
         <PhotoDetailSkeleton count={2} />
@@ -67,26 +67,35 @@ const SinglePhotoPage = () => {
     )
   }
 
-  if (aIsError) {
+  if (isPhotoError) {
     return (
       <>
-        <div className="grid justify-items-center">{aError.message}</div>
+        <div className="grid justify-items-center">{photoError.message}</div>
       </>
     )
   }
 
-  if (bIsError) {
+  if (isAlbumError) {
     return (
       <>
-        <div className="grid justify-items-center">{bError.message}</div>
+        <div className="grid justify-items-center">{albumError.message}</div>
       </>
     )
   }
 
-  if (cIsError) {
+  if (isUserError) {
     return (
       <>
-        <div className="grid justify-items-center">{cError.message}</div>
+        <div className="grid justify-items-center">{userError.message}</div>
+      </>
+    )
+  }
+
+  // Ensure all data is loaded before rendering
+  if (!photoData || !albumData || !userData) {
+    return (
+      <>
+        <PhotoDetailSkeleton count={2} />
       </>
     )
   }

--- a/src/components/photos/PhotoCard.js
+++ b/src/components/photos/PhotoCard.js
@@ -3,6 +3,11 @@ import { Link } from "react-router-dom"
 import PropTypes from "prop-types"
 
 const PhotoCard = (props) => {
+  const handleImageError = (e) => {
+    // Fallback to a solid color placeholder when image fails to load
+    e.target.src = `data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='600' height='600'%3E%3Crect width='600' height='600' fill='%23${props.photo.id ? (props.photo.id * 123456).toString(16).slice(0, 6) : "cccccc"}'/%3E%3Ctext x='50%25' y='50%25' font-size='24' fill='white' text-anchor='middle' dominant-baseline='middle'%3EPhoto ${props.photo.id}%3C/text%3E%3C/svg%3E`
+  }
+
   return (
     <>
       {!props.single ? (
@@ -18,14 +23,14 @@ const PhotoCard = (props) => {
           )}
 
           <Link to={`/photo/${props.photo.id}`} title={props.photo.title} className="single-photo flex flex-col transition p-0 text-black-600 font-normal text-sm text-center md:font-bold text-bold hover:text-primaryBlue-500 ">
-            <img src={props.photo.thumbnailUrl} alt={props.photo.title} className="block w-full self-start" />
+            <img src={props.photo.thumbnailUrl} alt={props.photo.title} className="block w-full self-start" onError={handleImageError} />
             <span className="p-3">{props.photo.title}</span>
           </Link>
         </div>
       ) : (
         <>
           <div className="flex justify-center items-start py-0 ">
-            <img src={props.photo.url} alt={props.photo.title} className="block w-full rounded-xl shadow-2xl" />
+            <img src={props.photo.url} alt={props.photo.title} className="block w-full rounded-xl shadow-2xl" onError={handleImageError} />
           </div>
 
           <div className="flex flex-col gap-4 px-1 mt-4 md:mt-0 md:px-6 md:col-span-1 xl:col-span-2">


### PR DESCRIPTION
Rename cryptic variable names in SinglePhotoPage and add image error handling for external placeholder service failures.

Variable naming improvements:
- Photo query: a* → photo* (photoResponse, isPhotoLoading, etc.)
- Album query: b* → album* (albumResponse, isAlbumLoading, etc.)
- User query: c* → user* (userResponse, isUserLoading, etc.)

Image loading fixes:
- Add onError handler to PhotoCard images
- Generate dynamic SVG fallback when via.placeholder.com fails
- Add null checks before rendering to prevent undefined access
- Each photo gets unique colored placeholder based on ID

Impact:
- Improved code readability and maintainability
- Resilient to external image service failures
- Better user experience with fallback images